### PR TITLE
Adding the RA MTU option

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ declarative configuration interface on top of it.
 
 - Basic RA mechanism defined in RFC4861
 - Router MAC address discovery with Source Link Layer Address option
-- TBD: MTU discovery with MTU option
+- MTU discovery with MTU option
 - Stateless Address Auto Configuration (SLAAC) with Prefix Information option
 - TBD: DNS auto configuration with RDNSS option
 

--- a/config.go
+++ b/config.go
@@ -68,6 +68,11 @@ type InterfaceConfig struct {
 	// this router.
 	RetransmitTimeMilliseconds int `yaml:"retransmitTimeMilliseconds" json:"retransmitTimeMilliseconds" validate:"gte=0,lte=4294967295"`
 
+	// The maximum transmission unit (MTU) that should be used for outgoing
+	// This value specifies the largest packet size, in bytes,
+	// If set to zero or not specified, MTU opton will not be advertised
+	MTU int `yaml:"mtu" json:"mtu" validate:"gte=0,lte=4294967295"`
+
 	// Prefix-specific configuration parameters. The prefix fields must be
 	// non-overlapping with each other. The slice itself and elements must
 	// not be nil.

--- a/config_test.go
+++ b/config_test.go
@@ -282,6 +282,36 @@ func TestConfigValidation(t *testing.T) {
 			errorTag:    "lte",
 		},
 		{
+			name: "MTU > 0",
+			config: &Config{
+				Interfaces: []*InterfaceConfig{
+					{
+						Name:                   "net0",
+						RAIntervalMilliseconds: 1000,
+						MTU:                    -1,
+					},
+				},
+			},
+			expectError: true,
+			errorField:  "MTU",
+			errorTag:    "gte",
+		},
+		{
+			name: "MTU > 4294967295",
+			config: &Config{
+				Interfaces: []*InterfaceConfig{
+					{
+						Name:                   "net0",
+						RAIntervalMilliseconds: 1000,
+						MTU:                    4294967296,
+					},
+				},
+			},
+			expectError: true,
+			errorField:  "MTU",
+			errorTag:    "lte",
+		},
+		{
 			name: "Nil PrefixConfig",
 			config: &Config{
 				Interfaces: []*InterfaceConfig{


### PR DESCRIPTION
Implemented the MTU option for Router Advertisement Message (RA) described in RFC4681.
With the addition of this option, it is possible to publicize RA containing MTU from config. 

