### PR TITLE
Add pref64 option support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ declarative configuration interface on top of it.
 - Prefix discovery with Prefix Information option
 - DNS configuration discovery with RDNSS/DNSSL option
 - Route advertisement with Route Information option
+- NAT64 prefix discovery with PREF64 option
 
 ## Installation
 

--- a/advertiser.go
+++ b/advertiser.go
@@ -125,6 +125,13 @@ func (s *advertiser) createOptions(config *InterfaceConfig, deviceState *deviceS
 		})
 	}
 
+	for _, nat64prefix := range config.NAT64Prefixes {
+		options = append(options, &ndp.PREF64{
+			Lifetime: time.Second * time.Duration(*nat64prefix.LifetimeSeconds),
+			Prefix:   netip.MustParsePrefix(nat64prefix.Prefix),
+		})
+	}
+
 	return options
 }
 

--- a/config_test.go
+++ b/config_test.go
@@ -1039,6 +1039,167 @@ func TestConfigValidation(t *testing.T) {
 			errorField:  "DomainNames[0]",
 			errorTag:    "domain",
 		},
+
+		// NAT64PrefixConfig
+		{
+			name: "Nil NAT64PrefixConfig",
+			config: &Config{
+				Interfaces: []*InterfaceConfig{
+					{
+						Name:                   "net0",
+						RAIntervalMilliseconds: 1000,
+						NAT64Prefixes:          nil,
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "Empty NAT64PrefixConfig",
+			config: &Config{
+				Interfaces: []*InterfaceConfig{
+					{
+						Name:                   "net0",
+						RAIntervalMilliseconds: 1000,
+						NAT64Prefixes:          []*NAT64PrefixConfig{},
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "Nil NAT64PrefixConfig Element",
+			config: &Config{
+				Interfaces: []*InterfaceConfig{
+					{
+						Name:                   "net0",
+						RAIntervalMilliseconds: 1000,
+						NAT64Prefixes:          []*NAT64PrefixConfig{nil},
+					},
+				},
+			},
+			expectError: true,
+			errorField:  "Prefix",
+			errorTag:    "required",
+		},
+		{
+			name: "No NAT64Prefix",
+			config: &Config{
+				Interfaces: []*InterfaceConfig{
+					{
+						Name:                   "net0",
+						RAIntervalMilliseconds: 1000,
+						NAT64Prefixes: []*NAT64PrefixConfig{
+							{
+								LifetimeSeconds: ptr.To(1800),
+							},
+						},
+					},
+				},
+			},
+			expectError: true,
+			errorField:  "Prefix",
+			errorTag:    "required",
+		},
+		{
+			name: "Multiple NAT64PrefixConfig",
+			config: &Config{
+				Interfaces: []*InterfaceConfig{
+					{
+						Name:                   "net0",
+						RAIntervalMilliseconds: 1000,
+						NAT64Prefixes: []*NAT64PrefixConfig{
+							{
+								Prefix:          "fc64:ff9b::/96",
+								LifetimeSeconds: ptr.To(1800),
+							},
+							{
+								Prefix:          "fd64:ff9b::/96",
+								LifetimeSeconds: ptr.To(1800),
+							},
+						},
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "Invalid NAT64Prefix length",
+			config: &Config{
+				Interfaces: []*InterfaceConfig{
+					{
+						Name:                   "net0",
+						RAIntervalMilliseconds: 1000,
+						NAT64Prefixes: []*NAT64PrefixConfig{
+							{
+								Prefix: "64:ff9b::/104",
+							},
+						},
+					},
+				},
+			},
+			expectError: true,
+			errorField:  "Prefix",
+			errorTag:    "invalid_prefix_len",
+		},
+		{
+			name: "LifetimeSeconds = 65528",
+			config: &Config{
+				Interfaces: []*InterfaceConfig{
+					{
+						Name:                   "net0",
+						RAIntervalMilliseconds: 1000,
+						NAT64Prefixes: []*NAT64PrefixConfig{
+							{
+								Prefix:          "64:ff9b::/96",
+								LifetimeSeconds: ptr.To(65528),
+							},
+						},
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "LifetimeSeconds < 0",
+			config: &Config{
+				Interfaces: []*InterfaceConfig{
+					{
+						Name:                   "net0",
+						RAIntervalMilliseconds: 1000,
+						NAT64Prefixes: []*NAT64PrefixConfig{
+							{
+								Prefix:          "64:ff9b::/96",
+								LifetimeSeconds: ptr.To(-1),
+							},
+						},
+					},
+				},
+			},
+			expectError: true,
+			errorField:  "LifetimeSeconds",
+			errorTag:    "gte",
+		},
+		{
+			name: "LifetimeSeconds > 65528",
+			config: &Config{
+				Interfaces: []*InterfaceConfig{
+					{
+						Name:                   "net0",
+						RAIntervalMilliseconds: 1000,
+						NAT64Prefixes: []*NAT64PrefixConfig{
+							{
+								Prefix:          "64:ff9b::/96",
+								LifetimeSeconds: ptr.To(65529),
+							},
+						},
+					},
+				},
+			},
+			expectError: true,
+			errorField:  "LifetimeSeconds",
+			errorTag:    "lte",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This PR adds support for the PRF64 option (RFC8781). This enables to signalize NAT64 prefix to hosts via RA. The configuration parameters are as follows. `lifetimeSeconds` is optional.
```
interfaces:
- name: eth0
  ...
  nat64prefixes:
    - prefix: "64:ff9b::/96"
      lifetimeSeconds: 1800
```